### PR TITLE
adding port configuration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Directs all traffic to a single domain via 301 redirects.
 
 ### config.ru
     use Rack::ForceDomain, ENV["DOMAIN"]
-    
+
 ### environment.rb
     config.middleware.use Rack::ForceDomain, ENV["DOMAIN"]
 
@@ -18,3 +18,5 @@ Directs all traffic to a single domain via 301 redirects.
 Now all requests to www.foo.com (or anything else pointed at the app) will 301 to foo.com.
 
 If the `$DOMAIN` environment variable is missing, no redirection will occur.
+
+You can also give provide a port along with your domain "foo.com:3000".

--- a/Rakefile
+++ b/Rakefile
@@ -11,27 +11,7 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
-spec = Gem::Specification.new do |s|
-  # Change these as appropriate
-  s.name              = "rack-force_domain"
-  s.version           = "0.1.1"
-  s.summary           = "Force all visitors onto a single domain."
-  s.author            = "Tom Lea"
-  s.email             = "contrib@tomlea.co.uk"
-  s.homepage          = "http://tomlea.co.uk/"
-
-  s.has_rdoc          = true
-  s.extra_rdoc_files  = %w(README.markdown)
-  s.rdoc_options      = %w(--main README.markdown)
-
-  # Add any extra files to include in the gem
-  s.files             = %w(README.markdown) + Dir.glob("{test,lib}/**/*")
-
-  s.require_paths     = ["lib"]
-
-  s.rubyforge_project = "rack-force_domain"
-end
-
+spec = eval(File.read('rack-force_domain.gemspec'))
 Rake::GemPackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end

--- a/lib/rack/force_domain.rb
+++ b/lib/rack/force_domain.rb
@@ -3,13 +3,27 @@ require 'rack'
 class Rack::ForceDomain
   def initialize(app, domain)
     @app = app
-    @domain = domain
+    if domain and domain != ""
+      @domain = domain
+
+      # set host from domain
+      domain_parts = domain.split(":")
+      @host = domain_parts[0]
+
+      # add port if applicable
+      if domain_parts[1]
+        port = domain_parts[1].to_i
+        @port = port if port > 0
+      end
+    end
   end
 
   def call(env)
     request = Rack::Request.new(env)
-    if @domain and request.host != @domain
-      fake_request = Rack::Request.new(env.merge("HTTP_HOST" => @domain))
+    host_mismatch = (@host && request.host != @host)
+    port_mismatch = (@port && request.port != @port)
+    if host_mismatch or port_mismatch
+      fake_request = Rack::Request.new(env.merge("HTTP_HOST" => @domain, "SERVER_PORT" => @port || request.port))
       Rack::Response.new([], 301, "Location" => fake_request.url).finish
     else
       @app.call(env)

--- a/rack-force_domain.gemspec
+++ b/rack-force_domain.gemspec
@@ -1,0 +1,20 @@
+Gem::Specification.new do |s|
+  # Change these as appropriate
+  s.name              = "rack-force_domain"
+  s.version           = "0.1.1"
+  s.summary           = "Force all visitors onto a single domain."
+  s.author            = "Tom Lea"
+  s.email             = "contrib@tomlea.co.uk"
+  s.homepage          = "http://tomlea.co.uk/"
+
+  s.has_rdoc          = true
+  s.extra_rdoc_files  = %w(README.markdown)
+  s.rdoc_options      = %w(--main README.markdown)
+
+  # Add any extra files to include in the gem
+  s.files             = %w(README.markdown) + Dir.glob("{test,lib}/**/*")
+
+  s.require_paths     = ["lib"]
+
+  s.rubyforge_project = "rack-force_domain"
+end

--- a/test/force_domain_test.rb
+++ b/test/force_domain_test.rb
@@ -21,6 +21,14 @@ class ForceDomainTest < Test::Unit::TestCase
     assert !@called, "should not have passed through"
   end
 
+  def test_should_301_if_port_is_wrong
+    app = Rack::ForceDomain.new(lambda{|env| @called = true; [200, [], {}] } , "foo.com:3000")
+    status, body, headers = app.call(Rack::MockRequest.env_for("http://foo.com/baz"))
+    assert_equal 301, status
+    assert_equal "http://foo.com:3000/baz", headers["Location"]
+    assert !@called, "should not have passed through"
+  end
+
   def test_should_passthrough_for_correct_domain
     app = Rack::ForceDomain.new(lambda{|env| @called = true; [200, [], {}] } , "foo.com")
     status, body, headers = app.call(Rack::MockRequest.env_for("http://foo.com/baz"))


### PR DESCRIPTION
with this patch, rack-force_domain now supports ports. This is very useful for localhost where you want to force_domain to yourname.local:3000.

Also, I separated out the gemspec to make things work much better for bundler clients.

Please merge. Thanks
